### PR TITLE
Fixes bug with ruby 2.2.0

### DIFF
--- a/lib/degu/renum/enumerated_value.rb
+++ b/lib/degu/renum/enumerated_value.rb
@@ -212,7 +212,11 @@ module Degu
 
       # Sorts enumerated values into the order in which they're declared.
       def <=> other
-        index <=> other.index
+        if other.respond_to? :index
+          index <=> other.index
+        else
+          index <=> other
+        end
       end
 
       # Returns a marshalled string for this enum instance.


### PR DESCRIPTION
With ruby 2.2.0 a warning is displayed when a Enum element is compared to an non Enum element.